### PR TITLE
fix dub import path

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,5 +5,5 @@
 	"homepage": "http://adilbaig.github.com/Tiny-Redis/",
 	"license": "ISC",
 	"sourcePaths": ["tinyredis"],
-	"importPaths": ["tinyredis"]
+	"importPaths": ["."]
 }


### PR DESCRIPTION
I tried to use tinyredis via dub (http://code.dlang.org/packages/tinyredis), but it did not work for me.

I tried to compile these code:

``` d
import tinyredis.redis;

void main() {}
```

but `dub build` failed with errors:

```
[rnakano@macmini :/tmp/tinyredis-dub]$ dub build --force
tinyredis: ["tinyredis"]
tinyredis-dub: ["tinyredis-dub", "tinyredis"]
Building tinyredis configuration "library", build type debug.
Running dmd...
Building tinyredis-dub configuration "application", build type debug.
Compiling...
source/app.d(1): Error: module redis is in file 'tinyredis/redis.d' which cannot be read
import path[0] = source
import path[1] = ../../../Users/rnakano/.dub/packages/tinyredis-2.0.0/tinyredis
import path[2] = /usr/local/Cellar/dmd/2.065.0/import
FAIL .dub/build/application-debug-posix.osx-x86_64-dmd-A02FBEDB5D98AD1F417C80AC88CE9A1A tinyredis-dub executable
Error executing command build: DMD compile run failed with exit code 1
```

So dub (dmd) search library files from this path: `$(libraryRoot)/$(importPaths)/$(packageName)/$(fileName)`.
In this case, search path is  `$(tinyredisRoot)/tinyredis(importPaths)/tinyredis(packageName)/redis.d(filename)`. It is incorrect path.
dub should search redis.d from `$(tinyredisRoot)/.(importPaths)/tinyredis(packageName)/redis.d(filename)``
