### PR TITLE
Fix encoder for json string values

### DIFF
--- a/tinyredis/parser.d
+++ b/tinyredis/parser.d
@@ -30,14 +30,14 @@ public :
         byte[] bytes;
         if(!getData(mb[1 .. $], bytes)) //This could be an int value (:), a bulk byte length ($), a status message (+) or an error value (-)
             return response;
-            
+
         size_t tpos = 1 + bytes.length;
         
         if(tpos + 2 > mb.length)
             return response;
         else
             tpos += 2; //for "\r\n"
-        
+
         switch(type)
         {
              case '+' : 

--- a/tinyredis/redis.d
+++ b/tinyredis/redis.d
@@ -58,7 +58,7 @@ public :
         	// This automatically gives us PubSub
         	 
         	debug{ writeln(escape(toMultiBulk(key, args)));}
-        	 
+
         	conn.send(toMultiBulk(key, args));
         	Response[] r = receiveResponses(conn, 1);
             return cast(R)(r[0]);
@@ -198,6 +198,20 @@ unittest
     assert(r.type == ResponseType.MultiBulk);
     assert(r.values.length == 6);
     
+    // Test for:
+    // tinyredis.parser.RedisResponseException@tinyredis/parser.d(110):
+    //   ERR value is not a valid float
+    {
+      import std.json;
+      JSONValue json = parseJSON("{\"a\": \"b\"}");
+      redis.send(
+        "ZADD",
+        "test_key",
+        1,
+        json.toString()
+      );
+    }
+
     //Check pipeline
     redis.send("DEL ctr");
     auto responses = redis.pipeline(["SET ctr 1", "INCR ctr", "INCR ctr", "INCR ctr", "INCR ctr"]);


### PR DESCRIPTION
If you try to store a json straight to redis you might incur in this nasty bug

```
tinyredis.parser.RedisResponseException@tinyredis/parser.d(111): ERR value is not a valid float
----------------
5   redis                               0x0000000104f9b790 tinyredis.response.Response[] tinyredis.connection.receiveResponses(std.socket.TcpSocket, ulong) + 224
6   redis                               0x0000000104f81318 tinyredis.response.Response tinyredis.redis.Redis.send!(tinyredis.response.Response, immutable(char)[], int, immutable(char)[]).send(immutable(char)[], immutable(char)[], int, immutable(char)[]) + 272
7   redis                               0x0000000104f6d951 void tinyredis.redis.__unittestL173_1() + 1209
8   redis                               0x0000000104f6d0e9 void tinyredis.redis.__modtest() + 9
9   redis                               0x0000000104fc23cc int core.runtime.runModuleUnitTests().__foreachbody3(ref object.ModuleInfo*) + 48
10  redis                               0x0000000104fd2e05 int rt.minfo.moduleinfos_apply(scope int delegate(ref object.ModuleInfo*)).__foreachbody2(ref rt.sections_osx.SectionGroup) + 85
11  redis                               0x0000000104fd2d99 int rt.minfo.moduleinfos_apply(scope int delegate(ref object.ModuleInfo*)) + 49
12  redis                               0x0000000104fc226f runModuleUnitTests + 139
13  redis                               0x0000000104fcd947 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() + 23
14  redis                               0x0000000104fcd8fd void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) + 45
15  redis                               0x0000000104fcd879 _d_run_main + 449
16  redis                               0x0000000104f6d274 main + 20
17  libdyld.dylib                       0x00007fff8ed345fd start + 1
18  ???                                 0x0000000000000001 0x0 + 1
```

it happens even for a simple json like `{"a": "b"}`. The problem is in the way the encoder creates the final command to send redis, in case of the example the final command was

```
ZADD test_key 1 {"a": "b"}
```

making redis complain as reported above.

Proposed solution is to wrap non LUA script commands in an extra pair of `'` so that the command generated works fine

```
127.0.0.1:6379> ZADD test_key 1 '{"a": "b"}'
(integer) 1
127.0.0.1:6379> ZRANGE test_key 0 -1
1) "{\"a\": \"b\"}"
```

Tests included.
