### PR TITLE
allow ubyte[]

### DIFF
--- a/tinyredis/response.d
+++ b/tinyredis/response.d
@@ -10,6 +10,7 @@ private:
     import std.stdio : writeln;
     import std.algorithm : find;
     import std.conv  : to, text, ConvOverflowException;
+    import std.conv;
     import std.traits;
     
 public : 
@@ -195,7 +196,8 @@ public :
                 || is(T == short)
                 || is(T == int)
                 || is(T == long)
-                || is(T == string))
+                || is(T == string)
+		|| is(ubyte[]))
         {
             static if(is(T == bool))
                 return toBool();
@@ -203,6 +205,8 @@ public :
                 return toInt!(T)();
             else static if(is(T == string))
                 return toString();
+	    else static if(is(ubyte[]))
+	        return cast(ubyte[])(values);
         }
         
         /**


### PR DESCRIPTION
Hi.

Redis allows binary strings, and presently it is not possible to cast the response to make use of these.  I am still relatively green with templates in D, but this does seem to work.

(Possibly it was unncessary to import the  whole of std.conv).

Laeeth