### PR TITLE
Only enable debug with debug version tinyredis

### DIFF
--- a/tinyredis/connection.d
+++ b/tinyredis/connection.d
@@ -12,7 +12,7 @@ private:
     import tinyredis.parser;
     import tinyredis.response;
 
-debug {
+debug(tinyredis) {
 	import std.stdio : writeln;
 	import tinyredis.encoder : escape;
 }    
@@ -30,7 +30,7 @@ public:
      */
 	void send(TcpSocket conn, string encoded_cmd)
     {
-        debug { writeln("Request : '", escape(encoded_cmd) ~ "'"); }
+        debug(tinyredis) { writeln("Request : '", escape(encoded_cmd) ~ "'"); }
         
         auto sent = conn.send(encoded_cmd);
         if (sent != (cast(byte[])encoded_cmd).length)
@@ -57,7 +57,7 @@ public:
         {
             receive(conn, buffer);
             
-            debug{ writeln("BUFFER : ", escape(cast(string)buffer)); } 
+            debug(tinyredis) { writeln("BUFFER : ", escape(cast(string)buffer)); } 
             
             while(buffer.length > 0)
             {
@@ -96,7 +96,7 @@ public:
             
             if(buffer.length == 0 && MultiBulks.length == 0) //Make sure all the multi bulks got their data
             {
-                debug {
+                debug(tinyredis) {
                     if(minResponses > 1 && responses.length < minResponses)
                         writeln("WAITING FOR MORE RESPONSES ... ");
                 }
@@ -132,5 +132,5 @@ private :
             throw new ConnectionException("A socket error occurred!");
 
         buffer ~= buff[0 .. len];
-        debug { writeln("Response : ", "'" ~ escape(cast(string)buff) ~ "'", " Length : ", len); }
+        debug(tinyredis) { writeln("Response : ", "'" ~ escape(cast(string)buff) ~ "'", " Length : ", len); }
     }

--- a/tinyredis/encoder.d
+++ b/tinyredis/encoder.d
@@ -92,7 +92,7 @@ alias toMultiBulk encode;
 	
 	auto buffer = appender!(C[])();
 	buffer.reserve(cast(size_t)(command.length * 1.2)); //Reserve for 20% overhead. 
-//	debug std.stdio.writeln("COMMAND LENGTH : ", command.length, " BUFFER : ", buffer.capacity);
+//	debug(tinyredis) std.stdio.writeln("COMMAND LENGTH : ", command.length, " BUFFER : ", buffer.capacity);
 	
 	C c;
 
@@ -105,14 +105,14 @@ alias toMultiBulk encode;
     	*/
     	if((c == '"' || c == '\'')) {
     		start = i+1;
-//			debug std.stdio.writeln("START : ", start, " LENGTH : ", str.length);
+//			debug(tinyredis) std.stdio.writeln("START : ", start, " LENGTH : ", str.length);
 			
 			//Circuit breaker to avoid RangeViolation
     		while(++i < str.length
     			&& (str[i] != c || (str[i] == c && str[i-1] == '\\'))
     			){}
     		
-//    		debug std.stdio.writeln("QUOTED STRING : ", str[start .. i]);
+//    		debug(tinyredis) std.stdio.writeln("QUOTED STRING : ", str[start .. i]);
 			goto MULTIBULK_PROCESS;
 		}
     	
@@ -174,7 +174,7 @@ private @trusted uint accumulator(C, T...)(Appender!(C[]) w, T args)
 	return ctr;
 }
 
-debug @trusted C[] escape(C)(C[] str) if (isSomeChar!C)
+debug(tinyredis) @trusted C[] escape(C)(C[] str) if (isSomeChar!C)
 {
      return replace(str,"\r\n","\\r\\n");
 }

--- a/tinyredis/redis.d
+++ b/tinyredis/redis.d
@@ -56,7 +56,7 @@ public :
         	// For async calls, just flush the queue
         	// This automatically gives us PubSub
         	 
-        	debug{ writeln(escape(toMultiBulk(key, args)));}
+        	debug(tinyredis) { writeln(escape(toMultiBulk(key, args)));}
         	 
         	conn.send(toMultiBulk(key, args));
         	Response[] r = receiveResponses(conn, 1);
@@ -65,7 +65,7 @@ public :
         
         R send(R = Response)(string cmd)
         {
-        	debug{ writeln(escape(toMultiBulk(cmd)));}
+        	debug(tinyredis) { writeln(escape(toMultiBulk(cmd)));}
         	
         	conn.send(toMultiBulk(cmd));
         	Response[] r = receiveResponses(conn, 1);
@@ -77,7 +77,7 @@ public :
          */
         R sendRaw(R = Response)(string cmd)
         {
-        	debug{ writeln(escape(cmd));}
+        	debug(tinyredis) { writeln(escape(cmd));}
         	
         	conn.send(cmd);
         	Response[] r = receiveResponses(conn, 1);

--- a/tinyredis/response.d
+++ b/tinyredis/response.d
@@ -7,11 +7,10 @@ module tinyredis.response;
 private:
     import std.array : split, replace, join;
     import std.string : strip, format;
-    import std.stdio : writeln;
     import std.algorithm : find;
     import std.conv  : to, text, ConvOverflowException;
     import std.traits;
-    
+
 public : 
 
     const string CRLF = "\r\n";


### PR DESCRIPTION
Without this change, a lot of stuff from tinyredis is printed to stdout when building a debug build for applications using tinyredis.
Please create a version tag so that dub users (like myself) can use this.